### PR TITLE
Updating the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/golang-ci-orb*
+.idea
+.project
+.vscode
+vendor/*/
+.DS_Store

--- a/src/examples/use-default-with-neo4j.yml
+++ b/src/examples/use-default-with-neo4j.yml
@@ -1,0 +1,25 @@
+description: Simple example using orb's job build-and-test with the default (with neo4j) values of its parameters in
+  order to build, lint and test Go project
+
+usage:
+  version: 2.1
+
+  orbs:
+    ft-golang-ci: financial-times/golang-ci@1
+
+  workflows:
+    tests_and_docker:
+      jobs:
+        - ft-golang-ci/build-and-test:
+            name: build-and-test-project
+            executor-name: ft-golang-ci/default-with-neo4j
+
+        - ft-golang-ci/docker-build:
+            name: build-docker-image
+            requires:
+              - build-and-test-project
+    snyk-scanning:
+      jobs:
+        - ft-golang-ci/scan:
+            name: scan-dependencies
+            context: org-global

--- a/src/examples/use-default.yml
+++ b/src/examples/use-default.yml
@@ -1,22 +1,23 @@
 description: Simple example using orb's job build-and-test with the default values of its parameters in order to build, lint and test Go project
+
 usage:
   version: 2.1
+
   orbs:
-    golang-ci: epavlova/golang-ci@0.2.0
+    ft-golang-ci: financial-times/golang-ci@1
+
   workflows:
-    version: 2.1
-    tests_and_build_workflow:
+    tests_and_docker:
       jobs:
-        - golang-ci/build-and-test:
+        - ft-golang-ci/build-and-test:
             name: build-and-test-project
 
-        - golang-ci/scan:
-            name: scan-dependencies
-            context: some-context-with-snyk-token
-            requires:
-              - build-and-test-project
-
-        - golang-ci/docker-build:
+        - ft-golang-ci/docker-build:
             name: build-docker-image
             requires:
               - build-and-test-project
+    snyk-scanning:
+      jobs:
+        - ft-golang-ci/scan:
+            name: scan-dependencies
+            context: org-global


### PR DESCRIPTION
1. Updating the existing example with:
- ft namespace - `financial-times/golang-ci`
- versioning - how to refer the orb version, so every service on rebuild to pull the latest changes of the orb (version 1).
- `ft-golang-ci` - It would be nice if it is called like so when used. This way it is clear that this is something specific for FT. It took me quite a while to see that `golang-ci` was the name of the orb in the circleci configuration, so something that I can change/use and not something that should not be touched.

2. Adding an example on how to use executors - in this case using the `default-with-neo4j`.
May be due to the confusion around the naming (`golang-ci` vs. `ft-golang-ci`) helped with that, but again it took me some time to figure out how to refer the `default-with-neo4j` executor.