### PR TITLE
Feature/deploy to registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,77 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@9.0.0
+  orb-tools: circleci/orb-tools@9.0.1
   golang-ci: financial-times/golang-ci@<<pipeline.parameters.dev-orb-version>>
+
+tags_and_branches: &tags_and_branches
+  tags:
+    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+
+only_tags: &only_tags
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+
+only_branches: &only_branches
+  branches:
+    only: /.*/
 
 parameters:
   dev-orb-version:
-    default: 'dev:alpha'
+    default: dev:alpha
     type: string
+  run-integration-tests:
+    default: false
+    type: boolean
 
 workflows:
-  lint_pack-validate_publish-dev:
+  lint_publish-dev_prod-release:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint
+      - orb-tools/lint:
+          filters: *tags_and_branches
 
       - orb-tools/pack:
           requires:
             - orb-tools/lint
+          filters: *tags_and_branches
 
       - orb-tools/publish-dev:
           orb-name: financial-times/golang-ci
-          context: publish-orbs
-          publish-sha-version: false
+          context: cm-team-orb-publishing
           requires:
             - orb-tools/pack
+          filters: *tags_and_branches
 
-      # the following jobs act as integrations tests for this orb, we run them and expect not to error
-      # they should use the just published dev:alpha version
-      - golang-ci/build-and-test:
-          name: default-integration-tests
+      - orb-tools/trigger-integration-tests-workflow:
+          context: cm-team-orb-publishing
           requires:
             - orb-tools/publish-dev
+          filters: *only_branches
+
+      # This step is executed only on tag release. Please note that currently CircleCI is not able to execute
+      # the integration-tests workflow on tag release. So dev-promote-prod-from-git-tag job is not in the same
+      # workflow as the integration tests.
+      - orb-tools/dev-promote-prod-from-git-tag:
+          orb-name: financial-times/golang-ci
+          context: cm-team-orb-publishing
+          add-pr-comment: false
+          perform-branch-check: true
+          requires:
+            - orb-tools/publish-dev
+          filters: *only_tags
+
+  # The integration tests should be run in a separate workflow triggered by the one above so that they use
+  # the latest dev:alpha version of the orb that was released by the publish-dev job above.
+  integration-tests:
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - golang-ci/build-and-test:
+          name: default-integration-tests
+          filters: *only_branches
 
       - golang-ci/docker-build:
           name: docker-job-integration-tests
-          requires:
-            - orb-tools/publish-dev
+          filters: *only_branches

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # golang-ci
-CircleCI orb for performing common tasks from the CI of a project written in Go
+CircleCI orb for performing common CI tasks for a Go project
+
+#### How to use this project
+Please refer to [CircleCI registry](https://circleci.com/orbs/registry/orb/financial-times/golang-ci) for information how to use this orb.
+
+#### How the CI steps for this orb work
+
+There are two CircleCI workflows associated with this project. They have different behaviour depending on whether they are triggered by commit push or by creating/pushing specific git tag.
+1. On push
+
+When you are pushing a commit in any branch including master, the first workflow is going to: 
+* lint the orb's code
+* pack it into single yaml file 
+* deploy it as "dev:alpha" version. These dev versions of the orb are not visible in the CircleCI registry but can be referred by other projects and can be tested.
+* trigger a new CircleCI pipeline. The new pipeline actually allows the just uploaded dev version of the orb to be used. There is no way to refer to the newly deployed dev version of the orb in the same pipeline that it's been deployed.
+
+When you are pushing a commit, the second workflow is going to:
+* run integration tests for the orb using the just deployed dev version. The integration tests in our cases are actually running the main orb's jobs and ensuring they succeed.
+
+2. On tag
+
+When you are creating a new tag from master branch (you can use the simple GitHub UI to create new release with associated git tag), the first workflow is going to:
+* lint the orb's code
+* packed it into single yaml file 
+* deploy it as "dev:alpha" version
+* trigger a new CircleCI pipeline
+* deploy new version of the orb in the CircleCI registry
+
+In order to trigger the first workflow, your git tag should match the following regular expression `(major|minor|patch)-release-v\d+\.\d+\.\d+`. So if you want your release to upload new patch version of the orb, use tag patch-release-v1.0.1. Unfortunately the numbers in the release are ignored by CircleCI. It only takes into consideration if you tag is `major`, `minor` or `patch` and depending on that it just bumps the current version of the orb in the CircleCI registry. So if your release is `patch-relases-v1.1.12` and the current version of the orb in the registry is `v1.1.0`, you will actually release `v1.1.1` in the registry.
+
+If you are creating a tag from branch different than master, the last step that is deploying the new version to the CircleCI registry will fail.
+
+The second workflow is not triggered at all in cases where the first workflow is triggered by git tag. If you find a way to do so, please contribute.
+
+#### How to contribute to this project
+
+In order to create a new version of this orb and release it to CircleCI registry you should perform the following steps:
+- Checkout a new branch and make your changes there. 
+- Make sure that all checks are passing for your branch and make PR
+- You can test the orb at this point in another project referring to it as `financial-times/golang-ci@dev:alpha`
+- After the PR is approved by 3 reviewers, you can merge it to master
+- Create a GitHub release with the appropriate tag (described in the previous section)
+
+#### Some resource on writing CircleCI orbs
+[Orb Authoring](https://circleci.com/docs/2.0/orb-author/)
+
+[Orbs Concepts](https://circleci.com/docs/2.0/using-orbs/)
+
+[Orbs Reference Guide](https://circleci.com/docs/2.0/reusing-config/)
+
+[Orbs tools - writing CI/CD for the orbs themselves](https://circleci.com/orbs/registry/orb/circleci/orb-tools?version=9.0.0)
+
+[Orbs best practices](https://circleci.com/docs/2.0/orbs-best-practices/)

--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.18.0"
+    default: "v1.23.8"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -9,7 +9,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.23.1"
+    default: "v1.23.8"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string


### PR DESCRIPTION
The CircleCI config of the orb is updated so it can be deployed to CircleCI registry via git tag.
The README is updated with instructions how to do it.
The failing integration tests are fixed by updating the linter runner (golangci) version.