### PR TITLE
Get automatically default repo branch on the lint action

### DIFF
--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -17,4 +17,4 @@ steps:
       command: wget <<parameters.golangci-config>>
   - run:
       name: Run linters
-      command: golangci-lint run --new-from-rev=$(git rev-parse origin/master) --config .golangci.yml --build-tags=integration
+      command: golangci-lint run --new-from-rev=$(git rev-parse refs/remotes/origin/HEAD) --config .golangci.yml --build-tags=integration


### PR DESCRIPTION
Currently we check for linters' errors only for the code that is diff from master branch. 
This should help with the transition away from master branch.