### PR TITLE
Add docker auth creds to image pulls

### DIFF
--- a/src/executors/default-with-elasticsearch.yml
+++ b/src/executors/default-with-elasticsearch.yml
@@ -7,4 +7,10 @@ parameters:
     default: "5.3"
 docker:
   - image: golang:<<parameters.golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
   - image: elasticsearch:<<parameters.elasticsearch-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN

--- a/src/executors/default-with-mysql.yml
+++ b/src/executors/default-with-mysql.yml
@@ -16,9 +16,15 @@ parameters:
     default: "testdb"
 docker:
   - image: golang:<<parameters.golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       DB_TEST_URL: <<parameters.db-test-url>>
   - image: mysql:<<parameters.mysql-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
     command: [mysqld, --max-connections=45]
     environment:
       MYSQL_ROOT_PASSWORD: <<parameters.mysql-root-password>>

--- a/src/executors/default-with-neo4j.yml
+++ b/src/executors/default-with-neo4j.yml
@@ -7,7 +7,13 @@ parameters:
     default: "3.4.10-enterprise"
 docker:
   - image: golang:<<parameters.golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
   - image: neo4j:<<parameters.neo4j-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       NEO4J_AUTH: none
       NEO4J_HEAP_MEMORY: 256

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,3 +4,6 @@ parameters:
     default: "1"
 docker:
   - image: golang:<<parameters.golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN

--- a/src/executors/scanner.yml
+++ b/src/executors/scanner.yml
@@ -5,3 +5,6 @@ parameters:
     default: "1.13"
 docker:
   - image: circleci/golang:<<parameters.circleci-golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN


### PR DESCRIPTION
With the new rate limiting from Docker Hub for pulls, an authentication is introduced using a shared global context provided by Rel Eng team.