### PR TITLE
Add seabolt executor

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -12,11 +12,9 @@ steps:
   - run:
       name: Build source code
       command: |
-        SSH_INSTEAD_OF=$(git config --global --get url."ssh://git@github.com".insteadOf)
-        if [ -n "$SSH_INSTEAD_OF" ]; then
-          echo "Exists!"
+        if [ ! -z "$GITHUB_USERNAME" ] && [ ! -z "$GITHUB_TOKEN" ]; then
           git config --global --unset url."ssh://git@github.com".insteadOf
+          export GOPRIVATE="github.com/Financial-Times"
+          git config --global url."https://${<<parameters.github-username>>}:${<<parameters.github-token>>}@github.com".insteadOf "https://github.com"
         fi
-        export GOPRIVATE="github.com/Financial-Times"
-        git config --global url."https://${<<parameters.github-username>>}:${<<parameters.github-token>>}@github.com".insteadOf "https://github.com"
         go build -mod=readonly -v ./...

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -12,7 +12,11 @@ steps:
   - run:
       name: Build source code
       command: |
-        git config --global --unset url."ssh://git@github.com".insteadOf
+        SSH_INSTEAD_OF=$(git config --global --get url."ssh://git@github.com".insteadOf)
+        if [ -n "$SSH_INSTEAD_OF" ]; then
+          echo "Exists!"
+          git config --global --unset url."ssh://git@github.com".insteadOf
+        fi
         export GOPRIVATE="github.com/Financial-Times"
         git config --global url."https://${<<parameters.github-username>>}:${<<parameters.github-token>>}@github.com".insteadOf "https://github.com"
         go build -mod=readonly -v ./...

--- a/src/executors/default-with-neo4j-seabolt.yml
+++ b/src/executors/default-with-neo4j-seabolt.yml
@@ -1,0 +1,21 @@
+parameters:
+  seabolt-image-version:
+    type: string
+    default: "v1.3.0"
+  neo4j-image-version:
+    type: string
+    default: "3.5-enterprise"
+docker:
+  - image: coco/go-alpine-plus-seabolt:<<parameters.seabolt-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+  - image: neo4j:<<parameters.neo4j-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+    environment:
+      NEO4J_AUTH: none
+      NEO4J_HEAP_MEMORY: 256
+      NEO4J_CACHE_MEMORY: 256M
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"


### PR DESCRIPTION
- Add a new executor which uses our Seabolt image as a base
- `git config --global --unset` cmd fails if  `url.ssh://git@github.com` is missing. -> Fix: execute the cmd and download private dependencies only if git credentials are set

`financial-times/golang-ci@dev:alpha` tests:
https://app.circleci.com/pipelines/github/Financial-Times/upp-live-blog-validator/133/workflows/4696f1fc-138b-476d-b19a-2f437e194a0e/jobs/184
https://app.circleci.com/pipelines/github/Financial-Times/concordances-rw-neo4j/63/workflows/d315c870-7f1a-468f-9653-13eeb73ed891/jobs/396 - fails due to linting errors - nothing to do with the orb changes.