### PR TITLE
Add executor with parameters example

### DIFF
--- a/src/examples/use-default-with-mysql-with-params.yml
+++ b/src/examples/use-default-with-mysql-with-params.yml
@@ -1,0 +1,25 @@
+description: Example using orb's job build-and-test with default-with-mysql executor passing custom paramaters defined in the executor config in order to build, lint and test Go project with MySQL. Note that we can only pass parameters defined and used in the executor's config file.
+usage:
+  version: 2.1
+  orbs:
+    ft-golang-ci: financial-times/golang-ci@1
+  workflows:
+    tests_and_docker:
+      jobs:
+        - ft-golang-ci/build-and-test:
+            name: build-and-test-project
+            executor-name:
+              name: ft-golang-ci/default-with-mysql
+              mysql-root-password: "pass"
+              mysql-database: "test"
+
+        - ft-golang-ci/docker-build:
+            name: build-docker-image
+            requires:
+              - build-and-test-project
+
+    snyk-scanning:
+      jobs:
+        - ft-golang-ci/scan:
+            name: scan-dependencies
+            context: cm-team-snyk


### PR DESCRIPTION
A new example that shows a case how to pass custom - already defined - parameter values to an executor. 