### PR TITLE
Fix/uppsf 2471 expired dev orb failing CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ only_branches: &only_branches
   branches:
     only: /.*/
 
+only_master: &only_master
+  branches:
+    only:
+      - master
+
 parameters:
   dev-orb-version:
     default: dev:alpha
@@ -69,9 +74,45 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - golang-ci/build-and-test:
-          name: default-integration-tests
+          name: integration-tests-default
+          filters: *only_branches
+
+      - golang-ci/build-and-test:
+          name: integration-tests-with-neo4j
+          executor-name: golang-ci/default-with-neo4j
+          filters: *only_branches
+
+      - golang-ci/build-and-test:
+          name: integration-tests-with-elasticsearch
+          executor-name: golang-ci/default-with-elasticsearch
+          filters: *only_branches
+
+      - golang-ci/build-and-test:
+          name: integration-tests-with-mysql
+          executor-name: golang-ci/default-with-mysql
+          filters: *only_branches
+
+      - golang-ci/build-and-test:
+          name: integration-tests-with-postgres
+          executor-name: golang-ci/default-with-postgres
           filters: *only_branches
 
       - golang-ci/docker-build:
           name: docker-job-integration-tests
           filters: *only_branches
+
+  # Republish the dev:alpha orb every two months to ensure new pipelines don't get rejected due to expired dev orbs.
+  # We need to refer to the dev release of the orb for the integration-tests workflow. However when there is no dev orb
+  # release (or it's expired) this config file is marked as invalid and none of its workflows is allowed to run.
+  keep-dev-orb-alive:
+    triggers:
+      - schedule:
+          cron: "0 0 1 1,3,5,7,9,11 *"
+          filters: *only_master
+    jobs:
+      - orb-tools/pack
+      - orb-tools/publish-dev:
+          orb-name: financial-times/golang-ci
+          context: cm-team-orb-publishing
+          requires:
+            - orb-tools/pack


### PR DESCRIPTION
The CI config of the orb relies on `dev:alpha` release as it's used for integration tests in one of the workflows.
One of the steps in the CI is to build and put the dev release in the CircleCI repo so everything looked okay. However if the release doesn't exist at all(or it is expired) the config that is importing it is marked as invalid by CircleCI and is not executed at all so no chance to upload the latest dev release.

CircleCI deletes the dev orbs on every 90 days. If the changes in the orb are made in bigger intervals we encounter the problem above. So we will make additional workflow which is just releasing new dev release of the orb from master each 2months. The cron schedule syntax is a bit verbose bеcause CircleCI doesn't support the shorter version.


