### PR TITLE
Add job, executor and example for openapi validation

### DIFF
--- a/src/examples/use-openapi-validate.yml
+++ b/src/examples/use-openapi-validate.yml
@@ -1,0 +1,10 @@
+description: Example using orb's job openapi-validate with default node executor passing custom file name parameter in order to validate an openapi swagger file
+usage:
+  version: 2.1
+  orbs:
+    golang-ci: financial-times/golang-ci@1
+  workflows:
+    validate_workflow:
+      jobs:
+        - golang-ci/openapi-validate:
+            file-path: ./api/swagger.yml

--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -1,0 +1,3 @@
+description: CircleCI Node image is used for validating openapi swagger files
+docker:
+  - image: cimg/node:16.1.0

--- a/src/jobs/openapi-validate.yml
+++ b/src/jobs/openapi-validate.yml
@@ -1,0 +1,18 @@
+parameters:
+  file-path:
+    description: Path to the configuration file
+    type: string
+    default: ./api/api.yml
+  executor-name:
+    description: Executor for this job
+    type: executor
+    default: node
+
+executor: <<parameters.executor-name>>
+
+steps:
+  - checkout
+  - run: npm config set prefix '~/.local/'
+  - run: export PATH=~/.local/bin/:$PATH
+  - run: npm install -g @apidevtools/swagger-cli@4.0.4
+  - run: swagger-cli validate <<parameters.file-path>>


### PR DESCRIPTION
Add functionality to validate swagger files using the swagger-cli. The path to the file that needs validation is configurable and it has a default value './api/api.yml'
https://financialtimes.atlassian.net/browse/UPPSF-2500