### PR TITLE
Add snyk project param

### DIFF
--- a/src/jobs/scan.yml
+++ b/src/jobs/scan.yml
@@ -12,6 +12,10 @@ parameters:
     description: This specifies if builds should be failed or continued based on issues found by Snyk.
     type: boolean
     default: true
+  project:
+    description: Name of the project that will be created in snyk. Default is github repository.
+    type: string
+    default: Financial-Times/$CIRCLE_PROJECT_REPONAME
   github-username:
     description: username of user with access to private github repositories
     type: env_var_name
@@ -31,5 +35,6 @@ steps:
       command: git config --global url."https://${<<parameters.github-username>>}:${<<parameters.github-token>>}@github.com".insteadOf "https://github.com"
   - snyk/scan:
       monitor-on-build: true
+      project: << parameters.project >>
       severity-threshold: << parameters.severity-threshold >>
       fail-on-issues: << parameters.fail-on-issues >>


### PR DESCRIPTION
# Description

## What

Add a parameter to `snyk scan` job for setting `project` name. The default value of this property is set to `Financial-Times/{reposotory name}`

## Why

For go modules projects, when running `snyk monitor` the default snyk project name is the current name of the module. `github.com/Financial-Times/service`. 

There are two issues with this setup. 
First when we increment the major version of the module, by convention, the name changes `github.com/Financial-Times/service/v2`. This will create new project in snyk and we don't want that. 
Second is that `cyber-security` [vulnerabilities tool](https://vulnerabilities.in.ft.com/team/content) fails to match snyk project to biz-ops system for any go module project that is on `v2` or higher. This happens because the tool infers github repo from snyk  project name and matches that to biz-ops system.

The solution is to just set the snyk project name to be the repository name. That way we wouldn't lose any historical data when moving major versions and allows for the `vulnerabilities tool` to correctly associate the snyk project with biz-ops system. 

## Anything, in particular, you'd like to highlight to reviewers

Not sure what should be the behaviour for systems that share a repository. Like `annotations-rw-neo4j` and `suggestions-rw-neo4j`.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)