### PR TITLE
Feature/uppsf 2750 neo cluster executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,11 @@ workflows:
           filters: *only_branches
 
       - golang-ci/build-and-test:
+          name: integration-tests-with-neo4j-cluster
+          executor-name: golang-ci/default-with-neo4j-cluster
+          filters: *only_branches
+
+      - golang-ci/build-and-test:
           name: integration-tests-with-elasticsearch
           executor-name: golang-ci/default-with-elasticsearch
           filters: *only_branches

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Description
+
+## What
+
+Please be specific and try to describe your thought process. State the obvious, since this might be the first time the reviewer is looking at the code
+
+## Why
+
+Copy (if there is one) the text of the original Trello/JIRA ticket in here, with a link back to it for the curious.
+
+## Anything, in particular, you'd like to highlight to reviewers
+
+Mention here sections of code which you would like reviewers to pay extra attention to .E.g
+
+_Would appreciate a second pair of eyes on the test_  
+_I am not quite sure how this bit works_  
+_Is there a better library for doing x_  
+
+## Scope and particulars of this PR (Please tick all that apply)
+
+- [ ] Tech hygiene (dependency updating & other tech debt)
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Breaking change
+- [ ] Minor change (e.g. fixing a typo, adding config)
+
+___
+This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)

--- a/src/executors/default-with-neo4j-cluster.yml
+++ b/src/executors/default-with-neo4j-cluster.yml
@@ -23,8 +23,6 @@ docker:
       password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       NEO4J_AUTH: none
-      NEO4J_HEAP_MEMORY: 256
-      NEO4J_CACHE_MEMORY: 256M
       NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
       NEO4J_dbms_mode: CORE
       NEO4J_dbms_security_auth__enabled: false
@@ -52,8 +50,6 @@ docker:
       password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       NEO4J_AUTH: none
-      NEO4J_HEAP_MEMORY: 256
-      NEO4J_CACHE_MEMORY: 256M
       NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
       NEO4J_dbms_mode: CORE
       NEO4J_dbms_security_auth__enabled: false
@@ -81,8 +77,6 @@ docker:
       password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       NEO4J_AUTH: none
-      NEO4J_HEAP_MEMORY: 256
-      NEO4J_CACHE_MEMORY: 256M
       NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
       NEO4J_dbms_mode: CORE
       NEO4J_dbms_security_auth__enabled: false

--- a/src/executors/default-with-neo4j-cluster.yml
+++ b/src/executors/default-with-neo4j-cluster.yml
@@ -1,0 +1,99 @@
+parameters:
+  golang-image-version:
+    type: string
+    default: "1"
+  neo4j-image-version:
+    type: string
+    default: "4.3.6-enterprise"
+docker:
+  - image: golang:<<parameters.golang-image-version>>
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+
+  - image: neo4j:<<parameters.neo4j-image-version>>
+    name: core0
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+    environment:
+      NEO4J_AUTH: none
+      NEO4J_HEAP_MEMORY: 256
+      NEO4J_CACHE_MEMORY: 256M
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
+      NEO4J_dbms_mode: CORE
+      NEO4J_dbms_security_auth__enabled: false
+      NEO4J_dbms_default__database: neo4j
+      NEO4J_dbms_routing_enabled: true
+      NEO4J_causal__clustering_discovery__type: list
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: 3
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: 3
+      NEO4J_causal__clustering_initial__discovery__members: core0:5000
+      NEO4J_dbms_backup_listen__address: 0.0.0.0:6362
+      NEO4J_dbms_logs_query_enabled: INFO
+      NEO4J_dbms_default__advertised__address: core0
+      NEO4J_dbms_routing_advertised__address: :7697
+      NEO4J_dbms_routing_listen__address: :7697
+      NEO4J_causal__clustering_discovery__advertised__address: core0:5000
+      NEO4J_dbms_connector_http_listen__address: :7474
+      NEO4J_dbms_connector_https_listen__address: :6477
+      NEO4J_dbms_connector_bolt_listen__address: :7687
+      NEO4J_EDITION: enterprise
+
+  - image: neo4j:<<parameters.neo4j-image-version>>
+    name: core1
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+    environment:
+      NEO4J_AUTH: none
+      NEO4J_HEAP_MEMORY: 256
+      NEO4J_CACHE_MEMORY: 256M
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
+      NEO4J_dbms_mode: CORE
+      NEO4J_dbms_security_auth__enabled: false
+      NEO4J_dbms_default__database: neo4j
+      NEO4J_dbms_routing_enabled: true
+      NEO4J_causal__clustering_discovery__type: list
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: 3
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: 3
+      NEO4J_causal__clustering_initial__discovery__members: core0:5000
+      NEO4J_dbms_backup_listen__address: 0.0.0.0:6362
+      NEO4J_dbms_logs_query_enabled: INFO
+      NEO4J_dbms_default__advertised__address: core1
+      NEO4J_dbms_routing_advertised__address: :7697
+      NEO4J_dbms_routing_listen__address: :7697
+      NEO4J_causal__clustering_discovery__advertised__address: core1:5000
+      NEO4J_dbms_connector_http_listen__address: :7475
+      NEO4J_dbms_connector_https_listen__address: :6478
+      NEO4J_dbms_connector_bolt_listen__address: :7688
+      NEO4J_EDITION: enterprise
+
+  - image: neo4j:<<parameters.neo4j-image-version>>
+    name: core2
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_ACCESS_TOKEN
+    environment:
+      NEO4J_AUTH: none
+      NEO4J_HEAP_MEMORY: 256
+      NEO4J_CACHE_MEMORY: 256M
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
+      NEO4J_dbms_mode: CORE
+      NEO4J_dbms_security_auth__enabled: false
+      NEO4J_dbms_default__database: neo4j
+      NEO4J_dbms_routing_enabled: true
+      NEO4J_causal__clustering_discovery__type: list
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: 3
+      NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: 3
+      NEO4J_causal__clustering_initial__discovery__members: core0:5000
+      NEO4J_dbms_backup_listen__address: 0.0.0.0:6362
+      NEO4J_dbms_logs_query_enabled: INFO
+      NEO4J_dbms_default__advertised__address: core2
+      NEO4J_dbms_routing_advertised__address: :7697
+      NEO4J_dbms_routing_listen__address: :7697
+      NEO4J_causal__clustering_discovery__advertised__address: core2:5000
+      NEO4J_dbms_connector_http_listen__address: :7476
+      NEO4J_dbms_connector_https_listen__address: :6479
+      NEO4J_dbms_connector_bolt_listen__address: :7689
+      NEO4J_EDITION: enterprise

--- a/src/executors/default-with-neo4j-cluster.yml
+++ b/src/executors/default-with-neo4j-cluster.yml
@@ -5,11 +5,16 @@ parameters:
   neo4j-image-version:
     type: string
     default: "4.3.6-enterprise"
+  neo4j-test-url:
+    type: string
+    default: "neo4j://core0:7687"
 docker:
   - image: golang:<<parameters.golang-image-version>>
     auth:
       username: $DOCKERHUB_USERNAME
       password: $DOCKERHUB_ACCESS_TOKEN
+    environment:
+      NEO4J_TEST_URL: <<parameters.neo4j-test-url>>
 
   - image: neo4j:<<parameters.neo4j-image-version>>
     name: core0

--- a/src/executors/default-with-neo4j.yml
+++ b/src/executors/default-with-neo4j.yml
@@ -4,7 +4,7 @@ parameters:
     default: "1"
   neo4j-image-version:
     type: string
-    default: "3.4.10-enterprise"
+    default: "4.3.6-enterprise"
 docker:
   - image: golang:<<parameters.golang-image-version>>
     auth:

--- a/src/executors/default-with-neo4j.yml
+++ b/src/executors/default-with-neo4j.yml
@@ -16,6 +16,4 @@ docker:
       password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       NEO4J_AUTH: none
-      NEO4J_HEAP_MEMORY: 256
-      NEO4J_CACHE_MEMORY: 256M
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"


### PR DESCRIPTION
Add new executor that starts Neo4j in cluster mode with 3 instances. The default Neo4j version for the new executor is `4.3.6-enterprise`.

Also the old single instance Neo4j executor is updated to use default version of `4.3.6-enterprise`. This is done as preparation for migration to the new Neo in the coming weeks.

If there is a service that needs different Neo version, just set the `neo4j-image-version` param to the executor (applicable for both Neo executors).

JIRA ticket - https://financialtimes.atlassian.net/browse/UPPSF-2750.