### PR TITLE
Fix docker build job failing to run

### DIFF
--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -1,12 +1,8 @@
 parameters:
-  working-dir:
-    description: Working directory for this job
-    type: string
-    default: project
   docker-version:
-    description: Version of docker
+    description: Version of base CircleCI image
     type: string
-    default: "18"
+    default: "2022.01"
   github-username:
     description: username of user with access to private github repositories
     type: env_var_name
@@ -15,9 +11,8 @@ parameters:
     description: token to for the user with access to private github repositories
     type: env_var_name
     default: GITHUB_TOKEN
-working_directory: /<<parameters.working-dir>>
 docker:
-    - image: docker:<<parameters.docker-version>>
+    - image: cimg/base:<<parameters.docker-version>>
 steps:
   - checkout
   - setup_remote_docker


### PR DESCRIPTION
# Description

## What

Change base docker build job to address an issue with old OpenSSH version related to this GitHub change https://github.blog/2021-09-01-improving-git-protocol-security-github/

Discussion: https://discuss.circleci.com/t/circleci-user-key-uses-rsa-with-sha1-which-github-has-deprecated/42548

## Why

Copy (if there is one) the text of the original Trello/JIRA ticket in here, with a link back to it for the curious.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
