### PR TITLE
Allow Neo4j plugins to be enabled

### DIFF
--- a/src/executors/default-with-neo4j-cluster.yml
+++ b/src/executors/default-with-neo4j-cluster.yml
@@ -8,6 +8,9 @@ parameters:
   neo4j-test-url:
     type: string
     default: "neo4j://core0:7687"
+  neo4j-plugins:
+    type: string
+    default: "[]"
 docker:
   - image: golang:<<parameters.golang-image-version>>
     auth:
@@ -42,6 +45,7 @@ docker:
       NEO4J_dbms_connector_https_listen__address: :6477
       NEO4J_dbms_connector_bolt_listen__address: :7687
       NEO4J_EDITION: enterprise
+      NEO4JLABS_PLUGINS: <<parameters.neo4j-plugins>>
 
   - image: neo4j:<<parameters.neo4j-image-version>>
     name: core1
@@ -69,6 +73,7 @@ docker:
       NEO4J_dbms_connector_https_listen__address: :6478
       NEO4J_dbms_connector_bolt_listen__address: :7688
       NEO4J_EDITION: enterprise
+      NEO4JLABS_PLUGINS: <<parameters.neo4j-plugins>>
 
   - image: neo4j:<<parameters.neo4j-image-version>>
     name: core2
@@ -96,3 +101,4 @@ docker:
       NEO4J_dbms_connector_https_listen__address: :6479
       NEO4J_dbms_connector_bolt_listen__address: :7689
       NEO4J_EDITION: enterprise
+      NEO4JLABS_PLUGINS: <<parameters.neo4j-plugins>>

--- a/src/executors/default-with-neo4j.yml
+++ b/src/executors/default-with-neo4j.yml
@@ -5,6 +5,9 @@ parameters:
   neo4j-image-version:
     type: string
     default: "4.3.6-enterprise"
+  neo4j-plugins:
+    type: string
+    default: "[]"
 docker:
   - image: golang:<<parameters.golang-image-version>>
     auth:
@@ -17,3 +20,4 @@ docker:
     environment:
       NEO4J_AUTH: none
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+      NEO4JLABS_PLUGINS: <<parameters.neo4j-plugins>>


### PR DESCRIPTION
# Description
Added parameter in neo4j executors to allow enabling of plugins.

## What

The Docker image for Neo4j has an environment variable `NEO4JLABS_PLUGINS` which allows you to enable plugins as described in the [Neo4j docs](https://neo4j.com/docs/operations-manual/current/docker/operations/#docker-neo4jlabs-plugins).

## Why

Needed to enable APOC in tests for the [cm-neo4j-driver](https://github.com/Financial-Times/cm-neo4j-driver) in this [PR](https://github.com/Financial-Times/cm-neo4j-driver/pull/11).

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
