### PR TITLE
Switch linting and test steps order

### DIFF
--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -34,8 +34,8 @@ steps:
   - build:
       github-username: <<parameters.github-username>>
       github-token: <<parameters.github-token>>
+  - test:
+      coverage-report-folder: <<parameters.coverage-report-folder>>
   - lint:
       golangci-lint-version: <<parameters.golangci-lint-version>>
       golangci-config: <<parameters.golangci-config>>
-  - test:
-      coverage-report-folder: <<parameters.coverage-report-folder>>


### PR DESCRIPTION
# Description

## What

Switch linting and test steps order in the job `build-and-test`. That will allows us to run the unit tests even when the linting
is failing for some reason.

## Why

With the release of Go 1.18, golangci [stopped working](https://github.com/golangci/golangci-lint/issues/2649). This is blocking our test flow with the current implementation.

## Anything, in particular, you'd like to highlight to reviewers
There are actually other approaches to the problem but this one doesn't require changes in CI config of our services.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
