### PR TITLE
Change docker-build job base image

### DIFF
--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -3,10 +3,20 @@ parameters:
     description: Working directory for this job
     type: string
     default: project
-  docker-version:
-    description: Version of docker
+  base-image:
+    description: |
+      Docker base image. The default is image provided by CircleCI.
+      More info here https://circleci.com/docs/2.0/circleci-images/
     type: string
-    default: "18"
+    default: "cimg/base:2021.04"
+  dockerhub-username:
+    description: username for login in dockerhub to download base image
+    type: env_var_name
+    default: DOCKERHUB_USERNAME
+  dockerhub-token:
+    description: access token for login in dockerhub to download base image
+    type: env_var_name
+    default: DOCKERHUB_ACCESS_TOKEN
   github-username:
     description: username of user with access to private github repositories
     type: env_var_name
@@ -15,9 +25,12 @@ parameters:
     description: token to for the user with access to private github repositories
     type: env_var_name
     default: GITHUB_TOKEN
-working_directory: /<<parameters.working-dir>>
+working_directory: /home/circleci/<<parameters.working-dir>>
 docker:
-    - image: docker:<<parameters.docker-version>>
+    - image: <<parameters.base-image>>
+      auth:
+        username: ${<<parameters.dockerhub-username>>}
+        password: ${<<parameters.dockerhub-token>>}
 steps:
   - checkout
   - setup_remote_docker


### PR DESCRIPTION
# Description

## What

Change `docker-build` base image to use CircleCI pre-build image, based on Ubuntu LTS.

## Why

Because there were no git or ssh in the previous base image, CircleCI was using their native git client to checkout the code. 
We've experienced problems with that setup, where the client failed to pull all changes from the remote repository.

The new pre-build base image contains all the necessary tools to checkout and build the docker images. More info can be found here https://circleci.com/docs/2.0/circleci-images/

## Anything, in particular, you'd like to highlight to reviewers

There is a second approach to how to fix the issue and stop using CircleCIs native git client. And that is to add `setup` step before the `checkout` step in `docker-build` job. 
```yaml
steps:
  - run:
      name: install git and ssh
      command: apk add --update openssh-client git
  - checkout
```
This will add git and ssh to the image and CircleCI will not fail back to its git client. 

I've opted to use the pre-build image instead of this approach as it was the recommended way by CircleCI.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
