### PR TITLE
Fix/uppsf 3427 golangci ver

### DIFF
--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -6,7 +6,7 @@ parameters:
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string
-    default: "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/v1.3.1/golangci-config/.golangci.yml"
+    default: "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/v1.3.2/golangci-config/.golangci.yml"
 steps:
   - run:
       name: Download golangci-lint

--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.45.0"
+    default: "v1.48.0"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -13,7 +13,7 @@ parameters:
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string
-    default: "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/v1.3.1/golangci-config/.golangci.yml"
+    default: "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/v1.3.2/golangci-config/.golangci.yml"
   coverage-report-folder:
     description: Folder to temporarily store coverage results
     type: string

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -9,7 +9,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.45.0"
+    default: "v1.48.0"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string


### PR DESCRIPTION
# Description

## What

Use the latest golangci-lint runner version(v1.48.0) applicable for the latest go version (v.1.19).
Update the linter runner config file. No semantic changes to the config, only changed structure.
The later config was not working with v1.48.0 of the linter runner.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3427

## Scope and particulars of this PR (Please tick all that apply)

- [X] Tech hygiene (dependency updating & other tech debt)
- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
