### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.48.0"
+    default: "v1.51.1"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -9,7 +9,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.48.0"
+    default: "v1.51.1"
   golangci-config:
     description: Location for golangci config file to be used (downloaded with wget)
     type: string


### PR DESCRIPTION
# Description

## What

Upgrades to latest version of golangci-lint.

## Why

v1.48.0 is not compatible with Go 1.20

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
