### PR TITLE
Move linters config file to the orb repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,4 +47,4 @@ workflows:
           context: cm-team-orb-publishing
           requires:
             - publish-dev
-          filters: *only_branches
+          filters: *tags_and_branches

--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -7,13 +7,24 @@ parameters:
     description: >
       Location for golangci config file to be used (downloaded with wget)
     type: string
-    default:
-      "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/\
-      v1.3.2/golangci-config/.golangci.yml"
+    default: ""
 steps:
-  - run:
-      name: Download linters' config file
-      command: wget <<parameters.golangci-config>>
+  - when:
+      condition: <<parameters.golangci-config>>
+      steps:
+        - run:
+            name: Download linters' config file if given as parameter
+            command: wget -O .golangci.yml <<parameters.golangci-config>>
+  - unless:
+      condition: <<parameters.golangci-config>>
+      steps:
+        - run:
+            name: >
+              Copy linters' config file from orb source code into
+              the job executor’s filesystem
+            environment:
+              CONFIG_CONTENT: <<include(conf/.golangci.yml)>>
+            command: /bin/echo "$CONFIG_CONTENT" > .golangci.yml
   - run:
       name: Run linters
       environment:

--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -1,0 +1,56 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+    settings:
+    printf:
+    funcs:
+    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  revive:
+    confidence: 0
+  gocognit:
+    min-complexity: 20
+
+linters:
+  disable-all: true
+  enable:
+      - bodyclose
+      - deadcode
+      - errcheck
+      - gocognit
+      - gofmt
+      - goimports
+      - gosec
+      - gosimple
+      - govet
+      - ineffassign
+      - misspell
+      - revive
+      - staticcheck
+      - structcheck
+      - stylecheck
+      - typecheck
+      - unparam
+      - unused
+      - varcheck
+      - whitespace
+
+run:
+  skip-dirs:
+    - test/testdata_etc
+    - pkg/golinters/goanalysis/(checker|passes)
+
+issues:
+  exclude-rules:
+    - text: "weak cryptographic primitive"
+      linters:
+        - gosec
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.17.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -17,7 +17,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocognit
     - gofmt
@@ -29,12 +28,10 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 run:

--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -4,10 +4,10 @@ linters-settings:
     settings:
     printf:
     funcs:
-    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-    - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   revive:
     confidence: 0
   gocognit:
@@ -16,26 +16,26 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-      - bodyclose
-      - deadcode
-      - errcheck
-      - gocognit
-      - gofmt
-      - goimports
-      - gosec
-      - gosimple
-      - govet
-      - ineffassign
-      - misspell
-      - revive
-      - staticcheck
-      - structcheck
-      - stylecheck
-      - typecheck
-      - unparam
-      - unused
-      - varcheck
-      - whitespace
+    - bodyclose
+    - deadcode
+    - errcheck
+    - gocognit
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
 
 run:
   skip-dirs:
@@ -51,6 +51,7 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.17.x # use the fixed version to not introduce new linters unexpectedly
+  # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.17.x
   prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"
+    - echo "here I can run custom commands"

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -16,9 +16,7 @@ parameters:
     description: >
       Location for golangci config file to be used (downloaded with wget)
     type: string
-    default:
-      "https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/\
-      v1.3.2/golangci-config/.golangci.yml"
+    default: ""
   coverage-report-folder:
     description: Folder to temporarily store coverage results
     type: string


### PR DESCRIPTION
# Description

## What

Move linters config file to the orb repository and stop using deprecated linters.

If the param `golang-config` has value different than empty string, the orb lint step will keep its previous behaviour. The linters config will be obtained from this param.
The `golang-config` should specify url from which the config can be downloaded via `wget`.

However, now by default the `golangci-config` param is empty string and the linters config file will be copied from the orb repo to the CricleCI job executor’s filesystem.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4330

## Anything, in particular, you'd like to highlight to reviewers

_You can check the changes via the experiment branch of annotations-writer-ontotext:_

- [Job](https://app.circleci.com/pipelines/github/Financial-Times/annotations-writer-ontotext/137/workflows/7ad9a3c0-c83f-4479-960a-9715cba9f3f0/jobs/711) for dev orb with NO linter config change;
- [Job](https://app.circleci.com/pipelines/github/Financial-Times/annotations-writer-ontotext/138/workflows/07b01863-2f01-4606-a4da-a2b2d073e952/jobs/717) for dev orb with WITH linter config change;

_Both jobs use the linter config from the orb, one is with the deprecated linters, the later is changed not to use the deprecated linters._

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
