### PR TITLE
Fix/uppsf 4343 release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,7 @@ orbs:
 
 tags_and_branches: &tags_and_branches
   tags:
-    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
-
-only_branches: &only_branches
-  branches:
-    only: /.*/
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 workflows:
   lint-pack-publish-dev:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -6,13 +6,13 @@ orbs:
 
 tags_and_branches: &tags_and_branches
   tags:
-    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 only_tags: &only_tags
   branches:
     ignore: /.*/
   tags:
-    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 only_master: &only_master
   branches:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Mention here sections of code which you would like reviewers to pay extra attent
 
 _Would appreciate a second pair of eyes on the test_  
 _I am not quite sure how this bit works_  
-_Is there a better library for doing x_  
+_Is there a better library for doing x_
 
 ## Scope and particulars of this PR (Please tick all that apply)
 
@@ -24,6 +24,17 @@ _Is there a better library for doing x_
 - [ ] Documentation
 - [ ] Breaking change
 - [ ] Minor change (e.g. fixing a typo, adding config)
+
+## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"
+
+- [ ] Test coverage is not significantly decreased
+- [ ] All PR checks have passed
+- [ ] Changes are deployed on dev before asking for review
+- [ ] Documentation remains up-to-date
+    - [ ] OpenAPI definition file is updated
+    - [ ] README file is updated
+    - [ ] Documentation is updated in upp-docs and upp-public-docs
+    - [ ] Architecture diagrams are updated
 
 ___
 This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)

--- a/README.md
+++ b/README.md
@@ -6,49 +6,54 @@ Please refer to [CircleCI registry](https://circleci.com/orbs/registry/orb/finan
 
 #### How the CI steps for this orb work
 
-There are two CircleCI workflows associated with this project. They have different behaviour depending on whether they are triggered by commit push or by creating/pushing specific git tag.
+There are two CircleCI workflows associated with this project. They have different behaviour depending on whether they are triggered by commit push or by creating specific git tag.
 1. On push
 
-When you are pushing a commit in any branch including master, the first workflow is going to: 
-* lint the orb's code
-* pack it into single yaml file 
-* deploy it as "dev:alpha" version. These dev versions of the orb are not visible in the CircleCI registry but can be referred by other projects and can be tested.
-* trigger a new CircleCI pipeline. The new pipeline actually allows the just uploaded dev version of the orb to be used. There is no way to refer to the newly deployed dev version of the orb in the same pipeline that it's been deployed.
+When you are pushing a commit in any branch including master, the first setup workflow is going to: 
+* Lint the orb's code.
+* Pack the orb source code into single yaml file.
+* Review if the orb source code complies to predefined list of best practices.
+* Lint the orb shell scripts.
+* Deploy it as `dev:alpha` and `dev:<SHA1>` version. These dev versions of the orb are not visible in the CircleCI registry but can be referred by other projects and can be tested.
+* Trigger the next CircleCI workflow. The new workflow allows the just uploaded dev version of the orb to be used. There is no way to refer to the newly deployed dev version of the orb in the same pipeline that it's been deployed.
 
 When you are pushing a commit, the second workflow is going to:
-* run integration tests for the orb using the just deployed dev version. The integration tests in our cases are actually running the main orb's jobs and ensuring they succeed.
+* Run integration tests for the orb using the just deployed dev version. The integration tests in our case are actually running the main orb's jobs and ensuring they succeed.
 
 2. On tag
 
 When you are creating a new tag from master branch (you can use the simple GitHub UI to create new release with associated git tag), the first workflow is going to:
-* lint the orb's code
-* packed it into single yaml file 
-* deploy it as "dev:alpha" version
-* trigger a new CircleCI pipeline
-* deploy new version of the orb in the CircleCI registry
+* Lint the orb's code.
+* Pack the orb source code into single yaml file.
+* Review if the orb source code complies to predefined list of best practices.
+* Lint the orb shell scripts.
+* Deploy it as `dev:alpha` and `dev:<SHA1>` version. These dev versions of the orb are not visible in the CircleCI registry but can be referred by other projects and can be tested.
+* Trigger the next CircleCI workflow. The new workflow allows the just uploaded dev version of the orb to be used. There is no way to refer to the newly deployed dev version of the orb in the same pipeline that it's been deployed.
 
-In order to trigger the first workflow, your git tag should match the following regular expression `(major|minor|patch)-release-v\d+\.\d+\.\d+`. So if you want your release to upload new patch version of the orb, use tag patch-release-v1.0.1. Unfortunately the numbers in the release are ignored by CircleCI. It only takes into consideration if you tag is `major`, `minor` or `patch` and depending on that it just bumps the current version of the orb in the CircleCI registry. So if your release is `patch-relases-v1.1.12` and the current version of the orb in the registry is `v1.1.0`, you will actually release `v1.1.1` in the registry.
+When you are creating a git tag, the second workflow is going to:
+* Run integration tests for the orb using the just deployed dev version. The integration tests in our cases are actually running the main orb's jobs and ensuring they succeed.
+* Pack the orb source code into single yaml file.
+* Deploy the packed orb to the CircleCI registry as the new official orb version.
 
-If you are creating a tag from branch different than master, the last step that is deploying the new version to the CircleCI registry will fail.
-
-The second workflow is not triggered at all in cases where the first workflow is triggered by git tag. If you find a way to do so, please contribute.
+In order to trigger the deploying to registry step, your git tag should match the [semantic versioning standard](https://semver.org/).
+If you are creating a tag from branch different from master, the last step that is deploying the new version to the CircleCI registry will fail.
 
 #### How to contribute to this project
 
 In order to create a new version of this orb and release it to CircleCI registry you should perform the following steps:
 - Checkout a new branch and make your changes there. 
 - Make sure that all checks are passing for your branch and make PR
-- You can test the orb at this point in another project referring to it as `financial-times/golang-ci@dev:alpha`
-- After the PR is approved by 3 reviewers, you can merge it to master
-- Create a GitHub release with the appropriate tag (described in the previous section)
+- You can test the orb at this point in another project referring to it as `financial-times/golang-ci@dev:alpha` or `financial-times/golang-ci@dev:<SHA1>`
+- After the PR is approved by 2 reviewers, you can merge it to master
+- Create a GitHub release with the appropriate tag following [semantic versioning standard](https://semver.org/).
 
 #### Some resource on writing CircleCI orbs
-[Orb Authoring](https://circleci.com/docs/2.0/orb-author/)
+[Orb Authoring](https://circleci.com/docs/orb-author/)
 
-[Orbs Concepts](https://circleci.com/docs/2.0/using-orbs/)
+[Orbs Concepts](https://circleci.com/docs/orb-concepts/)
 
-[Orbs Reference Guide](https://circleci.com/docs/2.0/reusing-config/)
+[Orbs Reusable Config Reference Guide](https://circleci.com/docs/reusing-config/)
 
-[Orbs tools - writing CI/CD for the orbs themselves](https://circleci.com/orbs/registry/orb/circleci/orb-tools?version=9.0.0)
+[Orbs tools for CI/CD for the orbs themselves](https://circleci.com/developer/orbs/orb/circleci/orb-tools?version=11.6.1)
 
-[Orbs best practices](https://circleci.com/docs/2.0/orbs-best-practices/)
+[Orbs best practices](https://circleci.com/docs/orbs-best-practices/)


### PR DESCRIPTION
# Description

## What

Use semantic versioning standard for orb deploy tags.

Previous versions of the orb publishing workflow used orb specific naming convention for the tags that can trigger deploy to the CircleCI registry. The current standard that CircleCI uses is semantic versioning.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4343

## Anything, in particular, you'd like to highlight to reviewers

_Unfortunately, yet another change was made in the CI/CD standard for the orb publishing._

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
