### PR TITLE
Fix/uppsf 4343 pack before publish

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -74,6 +74,7 @@ workflows:
             - integration-tests-with-mysql
             - integration-tests-with-postgres
             - docker-job-integration-tests
+            - orb-tools/pack
           filters: *only_tags
 
   # Republish the dev:alpha orb every two months to ensure new pipelines don't get rejected due to expired dev orbs.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ When you are creating a git tag, the second workflow is going to:
 * Deploy the packed orb to the CircleCI registry as the new official orb version.
 
 In order to trigger the deploying to registry step, your git tag should match the [semantic versioning standard](https://semver.org/).
-If you are creating a tag from branch different from master, the last step that is deploying the new version to the CircleCI registry will fail.
 
 #### How to contribute to this project
 


### PR DESCRIPTION
# Description

## What

Make the orb pack step required before starting deploy to prod step.
The deploy to prod step is failing because it cannot find the packed orb at the moment.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4343

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
