### PR TITLE
Removed GO111MODULE env var and Updated Lint version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PROJECT=orb-integration-tests
 COPY . "/${PROJECT}"
 WORKDIR "/${PROJECT}"
 
+RUN go mod download
 RUN go build -mod=readonly -a -o /artifacts/${PROJECT}
 
 # Multi-stage build - copy certs and the binary into the image

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Financial-Times/golang-ci-orb
 
-go 1.13
+go 1.21

--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.55.2"
+    default: "v1.56.1"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)

--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.51.1"
+    default: "v1.55.2"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -7,11 +7,11 @@ steps:
   - run:
       name: Download goveralls
       command: |
-        GO111MODULE=off go get github.com/mattn/goveralls
+        go get github.com/mattn/goveralls
   - run:
-      name: Download go-junit-report
+      name: Install goveralls
       command: |
-        GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
+        go install github.com/mattn/goveralls
   - run:
       name: Create test folders
       command: |

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -11,7 +11,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.51.1"
+    default: "v1.56.1"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)

--- a/src/scripts/build-source.sh
+++ b/src/scripts/build-source.sh
@@ -2,4 +2,5 @@
 git config --global --unset url."ssh://git@github.com".insteadOf
 export GOPRIVATE="github.com/Financial-Times"
 git config --global url."https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+go mod download
 go build -mod=readonly -v ./...

--- a/src/scripts/golangci-lint.sh
+++ b/src/scripts/golangci-lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$(go env GOPATH)"/bin "${GOLANGCI_LINT_VERSION}"
 
-golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --config .golangci.yml --build-tags=integration
+GOGC=1 golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --config .golangci.yml --build-tags=integration

--- a/src/scripts/golangci-lint.sh
+++ b/src/scripts/golangci-lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$(go env GOPATH)"/bin "${GOLANGCI_LINT_VERSION}"
 
-GOGC=1 golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --config .golangci.yml --build-tags=integration
+golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --config .golangci.yml --build-tags=integration


### PR DESCRIPTION
# Description

GO111MODULE=off is no longer supported in [go 1.22](https://tip.golang.org/doc/go1.22) and that is breaking our builds.

## What

- Removed the env var `GO111MODULE`;
- Removed the `Download go-junit-report` step because it seems not to be used;
- Added `Install goveralls` step. That installs the `goveralls` command;
- Added `go mod download` in `build-source.sh` and `Dockerfile`. That gets any missed dependencies of the manually added packages and creates `go.sum` from the `go.mod`;
- Merged in Todor's changes in branch `feature/update-linter-and-go-versions`.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
