### PR TITLE
Update the version of snyk orb and Go version in scan executor

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -11,4 +11,4 @@ display:
   source_url: "https://github.com/Financial-Times/golang-ci-orb"
 
 orbs:
-  snyk: snyk/snyk@1.1.1
+  snyk: snyk/snyk@2.1.0

--- a/src/executors/scanner.yml
+++ b/src/executors/scanner.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   circleci-golang-image-version:
     type: string
-    default: "1.21.1"
+    default: "1.22"
 docker:
   - image: cimg/go:<<parameters.circleci-golang-image-version>>
     auth:

--- a/src/jobs/scan.yml
+++ b/src/jobs/scan.yml
@@ -47,3 +47,4 @@ steps:
       project: << parameters.project >>
       severity-threshold: << parameters.severity-threshold >>
       fail-on-issues: << parameters.fail-on-issues >>
+      token-variable: SNYK_TOKEN


### PR DESCRIPTION
# Description

## What


The reason for the change is that for our projects referring to Go 1.22 in their mod files, snyk scan was failing. 

[The executor go version is intentionally just to the minor release](https://circleci.com/developer/images/image/cimg/go#image-name).

Add the snyk scan steps adviced for the new snyk orb version - adding the `token-variable`.

## Why

All Go projects with the latest Go failing the snyk scan job from this orb.

## Anything, in particular, you'd like to highlight to reviewers

[Check how it is failing when upgraded](https://app.circleci.com/pipelines/github/Financial-Times/cm-concept-lists-api/92/workflows/d9028e4e-f8cf-4f3a-baac-d1b8fc0e35f6/jobs/191)  
[Check how it is fixed with this version of the orb](https://app.circleci.com/pipelines/github/Financial-Times/cm-concept-lists-api/93/workflows/2073d3c6-5ab8-4f5d-8c37-db1405f1545e/jobs/195)  


## Scope and particulars of this PR (Please tick all that apply)

- [X] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
