### PR TITLE
version update lint

### DIFF
--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.56.1"
+    default: "v1.60.1"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -11,7 +11,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.56.1"
+    default: "v1.60.1"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)


### PR DESCRIPTION
# Description

## What

Updated the golangcli-lint version to v1.60.1 from v1.56.1

## Why

CircleCI lint check was failing. After a bit of debugging the issue was with the lint version.



## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)


___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
