### PR TITLE
Upgrade golangci-lint to 2.4.0

### DIFF
--- a/src/commands/lint.yml
+++ b/src/commands/lint.yml
@@ -2,7 +2,7 @@ description: Runs golangci-lint toool with predefined linters' config
 parameters:
   golangci-lint-version:
     type: string
-    default: "v1.64.4"
+    default: "v2.4.0"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)

--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -1,54 +1,54 @@
-linters-settings:
-  govet:
-    check-shadowing: true
-    settings:
-    printf:
-    funcs:
-      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-      - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  revive:
-    confidence: 0
-  gocognit:
-    min-complexity: 20
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - errcheck
     - gocognit
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unparam
     - unused
     - whitespace
-
-run:
-  skip-dirs:
-    - test/testdata_etc
-    - pkg/golinters/goanalysis/(checker|passes)
-
-issues:
-  exclude-rules:
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  # use the fixed version to not introduce new linters unexpectedly
-  golangci-lint-version: 1.17.x
-  prepare:
-    - echo "here I can run custom commands"
+  settings:
+    gocognit:
+      min-complexity: 20
+    govet:
+      enable:
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    revive:
+      confidence: 0
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        text: weak cryptographic primitive
+    paths:
+      - test/testdata_etc
+      - pkg/golinters/goanalysis/(checker|passes)
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - test/testdata_etc
+      - pkg/golinters/goanalysis/(checker|passes)

--- a/src/jobs/build-and-test.yml
+++ b/src/jobs/build-and-test.yml
@@ -11,7 +11,7 @@ parameters:
     default: default
   golangci-lint-version:
     type: string
-    default: "v1.64.4"
+    default: "v2.4.0"
   golangci-config:
     description: >
       Location for golangci config file to be used (downloaded with wget)


### PR DESCRIPTION
# Description

## What

Upgrade the linter version to support Go 1.25
This is major version upgrade and a change in the linter config was required. There's a migration guide with a `migrate` command which does a lot of work - https://golangci-lint.run/docs/product/migration-guide/

### Changes in config V1 to V2
`stylecheck`, `gosimple` and `staticcheck` are merged into `staticcheck`
https://golangci-lint.run/docs/product/migration-guide/#lintersenablestylecheckgosimplestaticcheck

`typecheck` is removed alltogether
https://golangci-lint.run/docs/product/migration-guide/#typecheck

`check-shadowing` is deprecated and now is just `shadow`
https://golangci-lint.run/docs/product/migration-guide/#linters-settingsgovetcheck-shadowing

`run.skip-dirs` is deprecated, the new setting
https://golangci-lint.run/docs/product/migration-guide/#runskip-dirs

`service` block is not supported, so I've removed it

`gofmt` and `goimport` are moved from **linters** to **formatters**
https://golangci-lint.run/docs/product/migration-guide/#lintersenableformatter_name

### Testing
I've tested it in another project but also locally by comparing V1 and V2 linter messages
## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-6118)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
