### PR TITLE
Lint the entire file where changes were made

### DIFF
--- a/src/scripts/golangci-lint.sh
+++ b/src/scripts/golangci-lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b "$(go env GOPATH)"/bin "${GOLANGCI_LINT_VERSION}"
 
-golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --config .golangci.yml --build-tags=integration
+golangci-lint run --new-from-rev="$(git rev-parse refs/remotes/origin/HEAD)" --whole-files --config .golangci.yml --build-tags=integration


### PR DESCRIPTION
# Description

## What

We're running the linter only for changed code, not the whole project using `new-from-rev`.  In the past the behavior of `new-from-rev` was lint the whole file where the change was made. Now we need to add an additional flag `--whole-files` to achieve the same thing.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-6118)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
