### PR TITLE
chore(lint): adopt new golangci-lint rules and settings

### DIFF
--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -14,6 +14,13 @@ linters:
     - unparam
     - unused
     - whitespace
+    - nilnesserr
+    - nilerr
+    - exhaustive
+    - errorlint
+    - recvcheck
+    - predeclared
+    - exptostd
   settings:
     gocognit:
       min-complexity: 20
@@ -27,6 +34,12 @@ linters:
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    exhaustive:
+      # Treat presence of a default clause as exhaustive
+      default-signifies-exhaustive: true
+    recvcheck:
+      # Do not report on built-in types
+      disable-builtin: true
     revive:
       confidence: 0
   exclusions:


### PR DESCRIPTION
# Description

## What

  - Enable additional linters in src/conf/.golangci.yml: - nilnesserr - nilerr - exhaustive - errorlint - recvcheck - predeclared - exptostd
  - Configure linter settings:
      - exhaustive.default-signifies-exhaustive: true (aka "default counts")
      - recvcheck.disable-builtin: true
  - Keep config schema version "2"; compatible with orb’s default golangci-lint v2.4.0.
  - No source changes; local lint run reports "0 issues".

## Why

[UPPSF-6433](https://financialtimes.atlassian.net/browse/UPPSF-6433)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
