### PR TITLE
fix: update revive linter configuration to disable exported rule

### DIFF
--- a/src/conf/.golangci.yml
+++ b/src/conf/.golangci.yml
@@ -39,6 +39,9 @@ linters:
       default-signifies-exhaustive: true
     revive:
       confidence: 0
+      rules:
+        - name: exported
+          disabled: true
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
# Description

## What

This PR disables the `exported` rule in the revive linter configuration to remove the requirement for documentation comments on all exported identifiers (functions, methods, constants, types).

The change was made in `.golangci.yml` by adding the `exported` rule to the revive settings with `disabled: true`. This eliminates the need for `//nolint:revive` comments on self-explanatory code such as simple getter methods and descriptive constants.

## Why

The strict enforcement of documentation comments on all exported identifiers was creating noise in the codebase with `//nolint:revive` suppressions for self-explanatory code. Many exported functions, methods, and constants are self-documenting through clear naming and don't benefit from redundant comments.

This change allows developers to focus on writing meaningful documentation where it adds value, rather than boilerplate comments to satisfy a linter rule.

## Anything, in particular, you'd like to highlight to reviewers

- The change only disables the `exported` rule; all other revive rules remain active
- Existing `//nolint:revive` comments can be removed from self-explanatory functions and constants
- Teams can still choose to document exported identifiers when it adds clarity, this just removes the enforcement

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [x] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
